### PR TITLE
Feature: add `disableSoloCheckedOption` prop to OptionsPanel component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@givewp/form-builder-library",
-    "version": "1.1.0",
+    "version": "1.1.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@givewp/form-builder-library",
-            "version": "1.1.0",
+            "version": "1.1.2",
             "dependencies": {
                 "@wordpress/components": "^25.10.0",
                 "@wordpress/compose": "^6.21.0",

--- a/src/OptionsPanel/OptionsItem.tsx
+++ b/src/OptionsPanel/OptionsItem.tsx
@@ -21,7 +21,7 @@ export default function OptionsItem({
     handleUpdateOptionChecked,
     handleRemoveOption,
     readOnly,
-    disabled,
+    disableSoloCheckedOption,
 }: OptionsItemProps) {
     return (
         <div className={'givewp-options-list--item'} ref={provided.innerRef} {...provided.draggableProps}>
@@ -42,7 +42,7 @@ export default function OptionsItem({
                             checked={option.checked}
                             className={'givewp-options-list--item--checked'}
                             onClick={() => handleUpdateOptionChecked(!option.checked)}
-                            disabled={disabled}
+                            disabled={disableSoloCheckedOption}
                         />
                     )}
                 </div>

--- a/src/OptionsPanel/OptionsItem.tsx
+++ b/src/OptionsPanel/OptionsItem.tsx
@@ -21,7 +21,7 @@ export default function OptionsItem({
     handleUpdateOptionChecked,
     handleRemoveOption,
     readOnly,
-    disableSoloCheckedOption,
+    disabled,
 }: OptionsItemProps) {
     return (
         <div className={'givewp-options-list--item'} ref={provided.innerRef} {...provided.draggableProps}>
@@ -42,7 +42,7 @@ export default function OptionsItem({
                             checked={option.checked}
                             className={'givewp-options-list--item--checked'}
                             onClick={() => handleUpdateOptionChecked(!option.checked)}
-                            disabled={disableSoloCheckedOption}
+                            disabled={disabled}
                         />
                     )}
                 </div>

--- a/src/OptionsPanel/OptionsItem.tsx
+++ b/src/OptionsPanel/OptionsItem.tsx
@@ -21,6 +21,7 @@ export default function OptionsItem({
     handleUpdateOptionChecked,
     handleRemoveOption,
     readOnly,
+    disabled,
 }: OptionsItemProps) {
     return (
         <div className={'givewp-options-list--item'} ref={provided.innerRef} {...provided.draggableProps}>
@@ -41,6 +42,7 @@ export default function OptionsItem({
                             checked={option.checked}
                             className={'givewp-options-list--item--checked'}
                             onClick={() => handleUpdateOptionChecked(!option.checked)}
+                            disabled={disabled}
                         />
                     )}
                 </div>

--- a/src/OptionsPanel/OptionsList.tsx
+++ b/src/OptionsPanel/OptionsList.tsx
@@ -13,6 +13,7 @@ export default function OptionsList({
     defaultControlsTooltip,
     onRemoveOption,
     readOnly,
+    disableSoloCheckedOption,
 }: OptionsListProps) {
     const handleRemoveOption = (index: number) => (): void => {
         if (onRemoveOption) {
@@ -96,8 +97,9 @@ export default function OptionsList({
                                             handleUpdateOptionValue={handleUpdateOptionValue(index)}
                                             handleUpdateOptionChecked={handleUpdateOptionChecked(index, multiple)}
                                             readOnly={readOnly}
-                                            disabled={
+                                            disableSoloCheckedOption={
                                                 multiple &&
+                                                disableSoloCheckedOption &&
                                                 option.checked &&
                                                 options.filter((option) => option.checked).length === 1
                                             }

--- a/src/OptionsPanel/OptionsList.tsx
+++ b/src/OptionsPanel/OptionsList.tsx
@@ -97,7 +97,7 @@ export default function OptionsList({
                                             handleUpdateOptionValue={handleUpdateOptionValue(index)}
                                             handleUpdateOptionChecked={handleUpdateOptionChecked(index, multiple)}
                                             readOnly={readOnly}
-                                            disableSoloCheckedOption={
+                                            disabled={
                                                 multiple &&
                                                 disableSoloCheckedOption &&
                                                 option.checked &&

--- a/src/OptionsPanel/OptionsList.tsx
+++ b/src/OptionsPanel/OptionsList.tsx
@@ -96,6 +96,11 @@ export default function OptionsList({
                                             handleUpdateOptionValue={handleUpdateOptionValue(index)}
                                             handleUpdateOptionChecked={handleUpdateOptionChecked(index, multiple)}
                                             readOnly={readOnly}
+                                            disabled={
+                                                multiple &&
+                                                option.checked &&
+                                                options.filter((option) => option.checked).length === 1
+                                            }
                                         />
                                     )}
                                 </Draggable>

--- a/src/OptionsPanel/index.tsx
+++ b/src/OptionsPanel/index.tsx
@@ -20,6 +20,7 @@ export default function Options({
     onRemoveOption,
     readOnly = false,
     label = __('Options', 'give'),
+    disableSoloCheckedOption = false,
 }: OptionsPanelProps) {
     const [showValues, setShowValues] = useState<boolean>(false);
 
@@ -56,6 +57,7 @@ export default function Options({
                         defaultControlsTooltip={defaultControlsTooltip}
                         onRemoveOption={onRemoveOption}
                         readOnly={readOnly}
+                        disableSoloCheckedOption={disableSoloCheckedOption}
                     />
                 </BaseControl>
             </PanelRow>

--- a/src/OptionsPanel/types.ts
+++ b/src/OptionsPanel/types.ts
@@ -11,6 +11,7 @@ export interface OptionsPanelProps {
     onAddOption?: () => void;
     label?: string;
     readOnly?: boolean;
+    disableSoloCheckedOption?: boolean;
 }
 
 export interface OptionsListProps {
@@ -23,6 +24,7 @@ export interface OptionsListProps {
     setOptions: (options: OptionProps[]) => void;
     onRemoveOption?: (option: OptionProps, index: number) => void;
     readOnly?: boolean;
+    disableSoloCheckedOption?: boolean;
 }
 
 export interface OptionsItemProps {
@@ -38,7 +40,7 @@ export interface OptionsItemProps {
     handleUpdateOptionChecked: (checked: boolean) => void;
     handleRemoveOption: () => void;
     readOnly?: boolean;
-    disabled?: boolean;
+    disableSoloCheckedOption?: boolean;
 }
 
 export interface OptionsHeaderProps {

--- a/src/OptionsPanel/types.ts
+++ b/src/OptionsPanel/types.ts
@@ -40,7 +40,7 @@ export interface OptionsItemProps {
     handleUpdateOptionChecked: (checked: boolean) => void;
     handleRemoveOption: () => void;
     readOnly?: boolean;
-    disableSoloCheckedOption?: boolean;
+    disabled?: boolean;
 }
 
 export interface OptionsHeaderProps {

--- a/src/OptionsPanel/types.ts
+++ b/src/OptionsPanel/types.ts
@@ -38,6 +38,7 @@ export interface OptionsItemProps {
     handleUpdateOptionChecked: (checked: boolean) => void;
     handleRemoveOption: () => void;
     readOnly?: boolean;
+    disabled?: boolean;
 }
 
 export interface OptionsHeaderProps {


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-187]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR automatically disables a checkbox when only itself is checked in the `OptionsList` of the `OptionsComponent`.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The `OptionsPanel` component.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://github.com/impress-org/form-builder-library/assets/16308864/e735b7eb-93a1-49da-a55b-b6999b3f98b4)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Run npm install && npm run build
2. Install the package locally
3. Let only one option checked in the settings of the Funds block implemented here: https://github.com/impress-org/give-funds/pull/125

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-187]: https://stellarwp.atlassian.net/browse/GIVE-187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ