### PR TITLE
Fix: style html editor

### DIFF
--- a/src/ClassicEditor/styles.scss
+++ b/src/ClassicEditor/styles.scss
@@ -5,8 +5,7 @@
 }
 
 .components-popover__content .givewp-classic-editor {
-    margin: 0.5rem;
-    width: initial;
+    margin: 0 !important;
 }
 
 .givewp-classic-editor {
@@ -64,6 +63,26 @@
 .givewp-classic-editor.show-editor-tabs {
     .wp-editor-tabs {
         display: block !important;
+    }
+
+    .quicktags-toolbar {
+        input.button.button-small {
+            font-size: 12px !important;
+            min-height: 26px;
+            line-height: 2;
+            color: var(--wp-admin-theme-color);
+            border-color: var(--wp-admin-theme-color) !important;
+            background: #f6f7f7;
+            vertical-align: top;
+            inline-size: auto;
+            padding: 0 8px;
+        }
+    }
+
+    .wp-editor-wrap.html-active {
+        textarea {
+            border: 0;
+        }
     }
 }
 


### PR DESCRIPTION
## Description

When using the editor in Text mode, toolbar buttons don't look good. This PR adds styles for them.

## Affects

Classic Editor in Text mode

## Visuals

![CleanShot 2024-01-08 at 19 05 04](https://github.com/impress-org/form-builder-library/assets/3921017/3e0e8022-4acf-4b7a-b13d-52440addba1f)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

