### PR TITLE
Feature: add new `draggable` prop to `OptionsPanel` component

### DIFF
--- a/src/OptionsPanel/OptionsItem.tsx
+++ b/src/OptionsPanel/OptionsItem.tsx
@@ -2,7 +2,7 @@ import cn from 'classnames';
 import {__} from '@wordpress/i18n';
 import {Button, Icon, Tooltip} from '@wordpress/components';
 
-import {draggable, minusCircle} from './icons';
+import {draggableIcon, minusCircle} from './icons';
 import {OptionsItemProps} from './types';
 import CurrencyControl from '../CurrencyControl';
 import {isCurrencyMode} from './utils';
@@ -22,11 +22,12 @@ export default function OptionsItem({
     handleRemoveOption,
     readOnly,
     disabled,
+    draggable,
 }: OptionsItemProps) {
     return (
         <div className={'givewp-options-list--item'} ref={provided.innerRef} {...provided.draggableProps}>
             <span className={'givewp-options-list--item--draggable'} {...provided.dragHandleProps}>
-                <Icon icon={draggable} />
+                {draggable && <Icon icon={draggableIcon} />}
             </span>
             <Tooltip
                 text={defaultTooltip ? defaultTooltip : __('Default', 'give')}

--- a/src/OptionsPanel/OptionsList.tsx
+++ b/src/OptionsPanel/OptionsList.tsx
@@ -14,6 +14,7 @@ export default function OptionsList({
     onRemoveOption,
     readOnly,
     disableSoloCheckedOption,
+    draggable,
 }: OptionsListProps) {
     const handleRemoveOption = (index: number) => (): void => {
         if (onRemoveOption) {
@@ -103,6 +104,7 @@ export default function OptionsList({
                                                 option.checked &&
                                                 options.filter((option) => option.checked).length === 1
                                             }
+                                            draggable={draggable}
                                         />
                                     )}
                                 </Draggable>

--- a/src/OptionsPanel/icons.tsx
+++ b/src/OptionsPanel/icons.tsx
@@ -17,7 +17,7 @@ export function minusCircle() {
     );
 }
 
-export function draggable() {
+export function draggableIcon() {
     return (
         <SVG xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
             <Path

--- a/src/OptionsPanel/index.tsx
+++ b/src/OptionsPanel/index.tsx
@@ -21,6 +21,7 @@ export default function Options({
     readOnly = false,
     label = __('Options', 'give'),
     disableSoloCheckedOption = false,
+    draggable = true,
 }: OptionsPanelProps) {
     const [showValues, setShowValues] = useState<boolean>(false);
 
@@ -58,6 +59,7 @@ export default function Options({
                         onRemoveOption={onRemoveOption}
                         readOnly={readOnly}
                         disableSoloCheckedOption={disableSoloCheckedOption}
+                        draggable={draggable}
                     />
                 </BaseControl>
             </PanelRow>

--- a/src/OptionsPanel/types.ts
+++ b/src/OptionsPanel/types.ts
@@ -12,6 +12,7 @@ export interface OptionsPanelProps {
     label?: string;
     readOnly?: boolean;
     disableSoloCheckedOption?: boolean;
+    draggable?: boolean;
 }
 
 export interface OptionsListProps {
@@ -25,6 +26,7 @@ export interface OptionsListProps {
     onRemoveOption?: (option: OptionProps, index: number) => void;
     readOnly?: boolean;
     disableSoloCheckedOption?: boolean;
+    draggable?: boolean;
 }
 
 export interface OptionsItemProps {
@@ -41,6 +43,7 @@ export interface OptionsItemProps {
     handleRemoveOption: () => void;
     readOnly?: boolean;
     disabled?: boolean;
+    draggable?: boolean;
 }
 
 export interface OptionsHeaderProps {


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

With the new `draggable` attribute, we can disable this feature in the `OptionsPanel` component when it's not necessary or allowed.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The `OptionsPanel` component.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://github.com/impress-org/form-builder-library/assets/16308864/bfcbeb4d-297e-4922-902f-49c766fec52e)


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Pull this repository in the `wp-content/plugins` folder and run the `npm install && npm run build` command inside the `form-builder-library` folder;
2. In the addon folder that you wish to test, go to the package.json file and add the following line as a dependency: `"@givewp/form-builder-library": "file:../form-builder-library"` and run the `npm install` command after that;
3. Try importing & using components like this: `import { OptionsPanel } from "@givewp/form-builder-library";`
4. Set the new `draggable` attribute to `false` and check if it gets hidden.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

