### PR TITLE
Feature: add block notice

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     },
     "devDependencies": {
         "@rollup/plugin-typescript": "^11.1.5",
+        "@types/react": "^18.2.67",
         "@types/react-beautiful-dnd": "^13.1.7",
         "node-sass": "^9.0.0",
         "postcss": "^8.4.32",

--- a/src/BlockNotice/index.tsx
+++ b/src/BlockNotice/index.tsx
@@ -5,15 +5,18 @@ type BlockNoticeProps = {
     title: string,
     description: string,
     href: string
+    anchorText: string;
     children?: ReactNode
 }
 
-export default function BlockNotice({title, description, href, children}: BlockNoticeProps) {
+export default function BlockNotice({title, description, href, anchorText, children}: BlockNoticeProps) {
     return (
         <div className={'givewp-block-notice'}>
             <span className={'givewp-block-notice__title'}>{title}</span>
             <span className={'givewp-block-notice__description'}>{description}</span>
-            <a className={'givewp-block-notice__anchor'} href={href} target={'_blank'} rel={'noreferrer noopener'} />
+            <a className={'givewp-block-notice__anchor'} href={href} target={'_blank'} rel={'noreferrer noopener'} >
+                {anchorText}
+            </a>
             {children}
         </div>
     );

--- a/src/BlockNotice/index.tsx
+++ b/src/BlockNotice/index.tsx
@@ -1,3 +1,5 @@
+import "./styles.scss";
+
 type BlockNoticeProps = {
     title: string,
     description: string,

--- a/src/BlockNotice/index.tsx
+++ b/src/BlockNotice/index.tsx
@@ -1,23 +1,25 @@
 import {ReactNode} from 'react';
-import "./styles.scss";
+import './styles.scss';
 
 type BlockNoticeProps = {
-    title: string,
-    description: string,
-    href: string
-    anchorText: string;
-    children?: ReactNode
-}
+    title: string;
+    description?: string;
+    href?: string;
+    anchorText?: string;
+    children?: ReactNode;
+};
 
 export default function BlockNotice({title, description, href, anchorText, children}: BlockNoticeProps) {
     return (
         <div className={'givewp-block-notice'}>
             <span className={'givewp-block-notice__title'}>{title}</span>
-            <span className={'givewp-block-notice__description'}>{description}</span>
-            <a className={'givewp-block-notice__anchor'} href={href} target={'_blank'} rel={'noreferrer noopener'} >
-                {anchorText}
-            </a>
+            {description && <span className={'givewp-block-notice__description'}>{description}</span>}
             {children}
+            {href && (
+                <a className={'givewp-block-notice__anchor'} href={href} target={'_blank'} rel={'noreferrer noopener'}>
+                    {anchorText}
+                </a>
+            )}
         </div>
     );
 }

--- a/src/BlockNotice/index.tsx
+++ b/src/BlockNotice/index.tsx
@@ -1,0 +1,15 @@
+type BlockNoticeProps = {
+    title: string,
+    description: string,
+    href: string
+}
+
+export default function BlockNotice({title, description, href}: BlockNoticeProps) {
+    return (
+        <div className={'givewp-block-notice'}>
+            <span className={'givewp-block-notice__title'}>{title}</span>
+            <span className={'givewp-block-notice__description'}>{description}</span>
+            <a className={'givewp-block-notice__anchor'} href={href} target={'_blank'} rel={'noreferrer noopener'} />
+        </div>
+    );
+}

--- a/src/BlockNotice/index.tsx
+++ b/src/BlockNotice/index.tsx
@@ -1,17 +1,20 @@
+import {ReactNode} from 'react';
 import "./styles.scss";
 
 type BlockNoticeProps = {
     title: string,
     description: string,
     href: string
+    children?: ReactNode
 }
 
-export default function BlockNotice({title, description, href}: BlockNoticeProps) {
+export default function BlockNotice({title, description, href, children}: BlockNoticeProps) {
     return (
         <div className={'givewp-block-notice'}>
             <span className={'givewp-block-notice__title'}>{title}</span>
             <span className={'givewp-block-notice__description'}>{description}</span>
             <a className={'givewp-block-notice__anchor'} href={href} target={'_blank'} rel={'noreferrer noopener'} />
+            {children}
         </div>
     );
 }

--- a/src/BlockNotice/styles.scss
+++ b/src/BlockNotice/styles.scss
@@ -1,0 +1,31 @@
+.givewp-block-notice {
+    padding: var(--givewp-spacing-3) var(--givewp-spacing-4);
+    background: #fffaf2;
+    border-radius: 2px;
+    border-left: 2px solid var(--givewp-orange-400);
+
+    span {
+        display: block;
+        font-size: 12px;
+    }
+
+    &__title {
+        font-weight: 600;
+        font-size: 0.75rem;
+        font-stretch: normal;
+        font-style: normal;
+        line-height: 1.33;
+        color: var(--givewp-grey-900);
+
+    }
+
+    &__description {
+        margin: var(--givewp-spacing-2) 0 var(--givewp-spacing-4) 0;
+        color: var(--givewp-grey-700);
+    }
+
+    &__anchor {
+        color: var(--givewp-grey-900);
+        cursor: pointer;
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export {default as CurrencyControl} from "./CurrencyControl";
 export {default as ClassicEditor} from "./ClassicEditor";
 export {default as OptionsPanel} from "./OptionsPanel";
 export {default as SettingsSection} from "./SettingsSection";
+export {default as BlockNotice} from "./BlockNotice";


### PR DESCRIPTION
## Description

This PR adds the block notice component to the library. It's being used in most add-ons that require setup of api credentials prior to adding the block. The notice serves as a way for users to get information on how to complete the required setup.

## Visuals

<img width="341" alt="Screen Shot 2024-03-21 at 7 06 45 AM" src="https://github.com/impress-org/form-builder-library/assets/75056371/bd8d5723-87e6-4856-baea-6f215635e363">

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [x] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

