### PR TITLE
Feature: update OptionsPanel component with descriptions

### DIFF
--- a/src/OptionsPanel/OptionsItem.tsx
+++ b/src/OptionsPanel/OptionsItem.tsx
@@ -19,79 +19,92 @@ export default function OptionsItem({
     handleUpdateOptionLabel,
     handleUpdateOptionValue,
     handleUpdateOptionChecked,
+    handleUpdateOptionDescription,
     handleRemoveOption,
     readOnly,
     disabled,
     draggable,
+    showDescription,
 }: OptionsItemProps) {
     return (
-        <div className={'givewp-options-list--item'} ref={provided.innerRef} {...provided.draggableProps}>
-            <span className={'givewp-options-list--item--draggable'} {...provided.dragHandleProps}>
-                {draggable && <Icon icon={draggableIcon} />}
-            </span>
-            <Tooltip
-                text={defaultTooltip ? defaultTooltip : __('Default', 'give')}
-                position="top"
-                placement="top"
-                delay={500}
-            >
-                {/* div is required (for some reason) for the Tooltip to work, do not remove */}
-                <div>
-                    {selectable && (
-                        <input
-                            type={multiple ? 'checkbox' : 'radio'}
-                            checked={option.checked}
-                            className={'givewp-options-list--item--checked'}
-                            onClick={() => handleUpdateOptionChecked(!option.checked)}
-                            disabled={disabled}
-                        />
-                    )}
-                </div>
-            </Tooltip>
-            <div
-                className={cn('givewp-options-list--item--inputs', {
-                    ['givewp-options-list--item--inputs--open']: showValues,
-                })}
-            >
-                {isCurrencyMode(currency) ? (
-                    <CurrencyControl
-                        currency={currency as CurrencyCode}
-                        label={__('Donation amount level', 'give')}
-                        hideLabelFromVision
-                        value={option.value}
-                        onValueChange={(value) => {
-                            handleUpdateOptionLabel(value);
-                            handleUpdateOptionValue(value);
-                        }}
-                    />
-                ) : (
-                    <>
-                        <input
-                            type={'text'}
-                            value={option.label}
-                            placeholder={__('Label', 'give')}
-                            onChange={(event) => handleUpdateOptionLabel(event.target.value)}
-                            readOnly={readOnly}
-                        />
-
-                        {showValues && (
+        <div ref={provided.innerRef} {...provided.draggableProps}>
+            <div className={'givewp-options-list--item'}>
+                <span className={'givewp-options-list--item--draggable'} {...provided.dragHandleProps}>
+                    {draggable && <Icon icon={draggableIcon} />}
+                </span>
+                <Tooltip
+                    text={defaultTooltip ? defaultTooltip : __('Default', 'give')}
+                    position="top"
+                    placement="top"
+                    delay={500}
+                >
+                    {/* div is required (for some reason) for the Tooltip to work, do not remove */}
+                    <div>
+                        {selectable && (
                             <input
-                                type={'text'}
-                                value={option.value}
-                                placeholder={__('Value', 'give')}
-                                onChange={(event) => handleUpdateOptionValue(event.target.value)}
-                                readOnly={readOnly}
+                                type={multiple ? 'checkbox' : 'radio'}
+                                checked={option.checked}
+                                className={'givewp-options-list--item--checked'}
+                                onClick={() => handleUpdateOptionChecked(!option.checked)}
+                                disabled={disabled}
                             />
                         )}
-                    </>
+                    </div>
+                </Tooltip>
+                <div
+                    className={cn('givewp-options-list--item--inputs', {
+                        ['givewp-options-list--item--inputs--open']: showValues,
+                    })}
+                >
+                    {isCurrencyMode(currency) ? (
+                        <CurrencyControl
+                            currency={currency as CurrencyCode}
+                            label={__('Donation amount level', 'give')}
+                            hideLabelFromVision
+                            value={option.value}
+                            onValueChange={(value) => {
+                                handleUpdateOptionLabel(value);
+                                handleUpdateOptionValue(value);
+                            }}
+                        />
+                    ) : (
+                        <>
+                            <input
+                                type={'text'}
+                                value={option.label}
+                                placeholder={__('Label', 'give')}
+                                onChange={(event) => handleUpdateOptionLabel(event.target.value)}
+                                readOnly={readOnly}
+                            />
+
+                            {showValues && (
+                                <input
+                                    type={'text'}
+                                    value={option.value}
+                                    placeholder={__('Value', 'give')}
+                                    onChange={(event) => handleUpdateOptionValue(event.target.value)}
+                                    readOnly={readOnly}
+                                />
+                            )}
+                        </>
+                    )}
+                </div>
+                {!readOnly && (
+                    <Button
+                        icon={minusCircle}
+                        className={'givewp-options-list--item--button'}
+                        onClick={() => handleRemoveOption()}
+                    />
                 )}
             </div>
-            {!readOnly && (
-                <Button
-                    icon={minusCircle}
-                    className={'givewp-options-list--item--button'}
-                    onClick={() => handleRemoveOption()}
-                />
+            {showDescription && (
+                <label className={'givewp-option-description'}>
+                    <textarea
+                        className={'givewp-options-description__input'}
+                        value={option.description}
+                        onChange={(event) => handleUpdateOptionDescription(event.target.value)}
+                    />
+                </label>
             )}
         </div>
     );

--- a/src/OptionsPanel/OptionsItem.tsx
+++ b/src/OptionsPanel/OptionsItem.tsx
@@ -12,51 +12,49 @@ export default function OptionsItem({
     currency,
     provided,
     option,
-    showValues,
+    showHidden,
     multiple,
     selectable,
     defaultTooltip,
     handleUpdateOptionLabel,
     handleUpdateOptionValue,
     handleUpdateOptionChecked,
-    handleUpdateOptionDescription,
     handleRemoveOption,
     readOnly,
     disabled,
     draggable,
-    showDescription,
 }: OptionsItemProps) {
     return (
-        <div ref={provided.innerRef} {...provided.draggableProps}>
-            <div className={'givewp-options-list--item'}>
-                <span className={'givewp-options-list--item--draggable'} {...provided.dragHandleProps}>
-                    {draggable && <Icon icon={draggableIcon} />}
-                </span>
-                <Tooltip
-                    text={defaultTooltip ? defaultTooltip : __('Default', 'give')}
-                    position="top"
-                    placement="top"
-                    delay={500}
-                >
-                    {/* div is required (for some reason) for the Tooltip to work, do not remove */}
-                    <div>
-                        {selectable && (
-                            <input
-                                type={multiple ? 'checkbox' : 'radio'}
-                                checked={option.checked}
-                                className={'givewp-options-list--item--checked'}
-                                onClick={() => handleUpdateOptionChecked(!option.checked)}
-                                disabled={disabled}
-                            />
-                        )}
-                    </div>
-                </Tooltip>
-                <div
-                    className={cn('givewp-options-list--item--inputs', {
-                        ['givewp-options-list--item--inputs--open']: showValues,
-                    })}
-                >
-                    {isCurrencyMode(currency) ? (
+        <div className={'givewp-options-list--item'} ref={provided.innerRef} {...provided.draggableProps}>
+            <span className={'givewp-options-list--item--draggable'} {...provided.dragHandleProps}>
+                {draggable && <Icon icon={draggableIcon} />}
+            </span>
+            <Tooltip
+                text={defaultTooltip ? defaultTooltip : __('Default', 'give')}
+                position="top"
+                placement="top"
+                delay={500}
+            >
+                {/* div is required (for some reason) for the Tooltip to work, do not remove */}
+                <div>
+                    {selectable && (
+                        <input
+                            type={multiple ? 'checkbox' : 'radio'}
+                            checked={option.checked}
+                            className={'givewp-options-list--item--checked'}
+                            onClick={() => handleUpdateOptionChecked(!option.checked)}
+                            disabled={disabled}
+                        />
+                    )}
+                </div>
+            </Tooltip>
+            <div
+                className={cn('givewp-options-list--item--inputs', {
+                    ['givewp-options-list--item--inputs--open']: showHidden,
+                })}
+            >
+                {isCurrencyMode(currency) ? (
+                    <>
                         <CurrencyControl
                             currency={currency as CurrencyCode}
                             label={__('Donation amount level', 'give')}
@@ -67,44 +65,41 @@ export default function OptionsItem({
                                 handleUpdateOptionValue(value);
                             }}
                         />
-                    ) : (
-                        <>
+                        {showHidden && (
+                            <textarea
+                                value={option.label}
+                                onChange={(event) => handleUpdateOptionLabel(event.target.value)}
+                            />
+                        )}
+                    </>
+                ) : (
+                    <>
+                        <input
+                            type={'text'}
+                            value={option.label}
+                            placeholder={__('Label', 'give')}
+                            onChange={(event) => handleUpdateOptionLabel(event.target.value)}
+                            readOnly={readOnly}
+                        />
+
+                        {showHidden && (
                             <input
                                 type={'text'}
-                                value={option.label}
-                                placeholder={__('Label', 'give')}
-                                onChange={(event) => handleUpdateOptionLabel(event.target.value)}
+                                value={option.value}
+                                placeholder={__('Value', 'give')}
+                                onChange={(event) => handleUpdateOptionValue(event.target.value)}
                                 readOnly={readOnly}
                             />
-
-                            {showValues && (
-                                <input
-                                    type={'text'}
-                                    value={option.value}
-                                    placeholder={__('Value', 'give')}
-                                    onChange={(event) => handleUpdateOptionValue(event.target.value)}
-                                    readOnly={readOnly}
-                                />
-                            )}
-                        </>
-                    )}
-                </div>
-                {!readOnly && (
-                    <Button
-                        icon={minusCircle}
-                        className={'givewp-options-list--item--button'}
-                        onClick={() => handleRemoveOption()}
-                    />
+                        )}
+                    </>
                 )}
             </div>
-            {showDescription && (
-                <label className={'givewp-option-description'}>
-                    <textarea
-                        className={'givewp-options-description__input'}
-                        value={option.description}
-                        onChange={(event) => handleUpdateOptionDescription(event.target.value)}
-                    />
-                </label>
+            {!readOnly && (
+                <Button
+                    icon={minusCircle}
+                    className={'givewp-options-list--item--button'}
+                    onClick={() => handleRemoveOption()}
+                />
             )}
         </div>
     );

--- a/src/OptionsPanel/OptionsItem.tsx
+++ b/src/OptionsPanel/OptionsItem.tsx
@@ -67,6 +67,7 @@ export default function OptionsItem({
                         />
                         {showHidden && (
                             <textarea
+                                className={'givewp-options-list__textarea'}
                                 value={option.label}
                                 onChange={(event) => handleUpdateOptionLabel(event.target.value)}
                             />

--- a/src/OptionsPanel/OptionsList.tsx
+++ b/src/OptionsPanel/OptionsList.tsx
@@ -15,6 +15,7 @@ export default function OptionsList({
     readOnly,
     disableSoloCheckedOption,
     draggable,
+    showDescription,
 }: OptionsListProps) {
     const handleRemoveOption = (index: number) => (): void => {
         if (onRemoveOption) {
@@ -75,6 +76,15 @@ export default function OptionsList({
         setOptions(updatedOptions);
     };
 
+    const handleUpdateOptionDescription =
+        (index: number) =>
+        (description: string): void => {
+            const updatedOptions = [...options];
+
+            updatedOptions[index].description = description;
+            setOptions(updatedOptions);
+        };
+
     return (
         <DragDropContext onDragEnd={handleUpdateOptionsOrder}>
             <Droppable droppableId="options">
@@ -97,6 +107,7 @@ export default function OptionsList({
                                             handleUpdateOptionLabel={handleUpdateOptionLabel(index)}
                                             handleUpdateOptionValue={handleUpdateOptionValue(index)}
                                             handleUpdateOptionChecked={handleUpdateOptionChecked(index, multiple)}
+                                            handleUpdateOptionDescription={handleUpdateOptionDescription(index)}
                                             readOnly={readOnly}
                                             disabled={
                                                 multiple &&
@@ -105,6 +116,7 @@ export default function OptionsList({
                                                 options.filter((option) => option.checked).length === 1
                                             }
                                             draggable={draggable}
+                                            showDescription={showDescription}
                                         />
                                     )}
                                 </Draggable>

--- a/src/OptionsPanel/OptionsList.tsx
+++ b/src/OptionsPanel/OptionsList.tsx
@@ -6,7 +6,7 @@ import {OptionProps, OptionsListProps} from './types';
 export default function OptionsList({
     currency,
     options,
-    showValues,
+    showHidden,
     multiple,
     selectable,
     setOptions,
@@ -15,7 +15,6 @@ export default function OptionsList({
     readOnly,
     disableSoloCheckedOption,
     draggable,
-    showDescription,
 }: OptionsListProps) {
     const handleRemoveOption = (index: number) => (): void => {
         if (onRemoveOption) {
@@ -76,15 +75,6 @@ export default function OptionsList({
         setOptions(updatedOptions);
     };
 
-    const handleUpdateOptionDescription =
-        (index: number) =>
-        (description: string): void => {
-            const updatedOptions = [...options];
-
-            updatedOptions[index].description = description;
-            setOptions(updatedOptions);
-        };
-
     return (
         <DragDropContext onDragEnd={handleUpdateOptionsOrder}>
             <Droppable droppableId="options">
@@ -99,7 +89,7 @@ export default function OptionsList({
                                             currency={currency}
                                             provided={provided}
                                             option={option}
-                                            showValues={showValues}
+                                            showHidden={showHidden}
                                             multiple={multiple}
                                             selectable={selectable}
                                             defaultTooltip={defaultControlsTooltip}
@@ -107,7 +97,6 @@ export default function OptionsList({
                                             handleUpdateOptionLabel={handleUpdateOptionLabel(index)}
                                             handleUpdateOptionValue={handleUpdateOptionValue(index)}
                                             handleUpdateOptionChecked={handleUpdateOptionChecked(index, multiple)}
-                                            handleUpdateOptionDescription={handleUpdateOptionDescription(index)}
                                             readOnly={readOnly}
                                             disabled={
                                                 multiple &&
@@ -116,7 +105,6 @@ export default function OptionsList({
                                                 options.filter((option) => option.checked).length === 1
                                             }
                                             draggable={draggable}
-                                            showDescription={showDescription}
                                         />
                                     )}
                                 </Draggable>

--- a/src/OptionsPanel/index.tsx
+++ b/src/OptionsPanel/index.tsx
@@ -22,8 +22,10 @@ export default function Options({
     label = __('Options', 'give'),
     disableSoloCheckedOption = false,
     draggable = true,
+    hasDescriptions,
 }: OptionsPanelProps) {
     const [showValues, setShowValues] = useState<boolean>(false);
+    const [showDescription, setShowDescription] = useState<boolean>(hasDescriptions);
 
     const handleAddOption = (): void => {
         if (onAddOption) {
@@ -31,7 +33,7 @@ export default function Options({
             return;
         }
 
-        setOptions([...options, {label: '', value: '', checked: false}]);
+        setOptions([...options, {label: '', value: '', checked: false, description: ''}]);
     };
 
     return (
@@ -42,6 +44,16 @@ export default function Options({
                         label={__('Show values', 'give')}
                         checked={showValues}
                         onChange={() => setShowValues(!showValues)}
+                    />
+                </PanelRow>
+            )}
+            {hasDescriptions && (
+                <PanelRow>
+                    <ToggleControl
+                        className={'givewp-amount-description-toggle'}
+                        label={__('Enable amount description', 'give')}
+                        checked={showDescription}
+                        onChange={() => setShowDescription(!showDescription)}
                     />
                 </PanelRow>
             )}
@@ -60,6 +72,7 @@ export default function Options({
                         readOnly={readOnly}
                         disableSoloCheckedOption={disableSoloCheckedOption}
                         draggable={draggable}
+                        showDescription={showDescription}
                     />
                 </BaseControl>
             </PanelRow>

--- a/src/OptionsPanel/index.tsx
+++ b/src/OptionsPanel/index.tsx
@@ -22,10 +22,10 @@ export default function Options({
     label = __('Options', 'give'),
     disableSoloCheckedOption = false,
     draggable = true,
-    hasDescriptions,
+    toggleLabel = __('Show values', 'give'),
 }: OptionsPanelProps) {
-    const [showValues, setShowValues] = useState<boolean>(false);
-    const [showDescription, setShowDescription] = useState<boolean>(hasDescriptions);
+    const initialShowHidden = options.some((option) => option.value && option.label);
+    const [showHidden, setShowHidden] = useState<boolean>(initialShowHidden);
 
     const handleAddOption = (): void => {
         if (onAddOption) {
@@ -33,37 +33,28 @@ export default function Options({
             return;
         }
 
-        setOptions([...options, {label: '', value: '', checked: false, description: ''}]);
+        setOptions([...options, {label: '', value: '', checked: false}]);
     };
 
     return (
         <>
-            {!isCurrencyMode(currency) && !readOnly && (
+            {!readOnly && (
                 <PanelRow>
                     <ToggleControl
-                        label={__('Show values', 'give')}
-                        checked={showValues}
-                        onChange={() => setShowValues(!showValues)}
+                        label={toggleLabel}
+                        checked={showHidden}
+                        onChange={() => setShowHidden(!showHidden)}
                     />
                 </PanelRow>
             )}
-            {hasDescriptions && (
-                <PanelRow>
-                    <ToggleControl
-                        className={'givewp-amount-description-toggle'}
-                        label={__('Enable amount description', 'give')}
-                        checked={showDescription}
-                        onChange={() => setShowDescription(!showDescription)}
-                    />
-                </PanelRow>
-            )}
+
             <PanelRow>
                 <BaseControl id={'give'}>
                     <OptionsHeader handleAddOption={handleAddOption} label={label} readOnly={readOnly} />
                     <OptionsList
                         currency={isCurrencyMode(currency) && (currency as CurrencyCode)}
                         options={options}
-                        showValues={showValues}
+                        showHidden={showHidden}
                         multiple={multiple}
                         selectable={selectable}
                         setOptions={setOptions}
@@ -72,7 +63,6 @@ export default function Options({
                         readOnly={readOnly}
                         disableSoloCheckedOption={disableSoloCheckedOption}
                         draggable={draggable}
-                        showDescription={showDescription}
                     />
                 </BaseControl>
             </PanelRow>

--- a/src/OptionsPanel/index.tsx
+++ b/src/OptionsPanel/index.tsx
@@ -23,9 +23,10 @@ export default function Options({
     disableSoloCheckedOption = false,
     draggable = true,
     toggleLabel = __('Show values', 'give'),
+    toggleEnabled = false,
+    onHandleToggle,
 }: OptionsPanelProps) {
-    const initialShowHidden = options.some((option) => option.value && option.label);
-    const [showHidden, setShowHidden] = useState<boolean>(initialShowHidden);
+    const [showHidden, setShowHidden] = useState<boolean>(toggleEnabled);
 
     const handleAddOption = (): void => {
         if (onAddOption) {
@@ -36,15 +37,16 @@ export default function Options({
         setOptions([...options, {label: '', value: '', checked: false}]);
     };
 
+    const handleToggle = () => {
+        setShowHidden(!showHidden);
+        onHandleToggle(!showHidden);
+    };
+
     return (
         <>
             {!readOnly && (
                 <PanelRow>
-                    <ToggleControl
-                        label={toggleLabel}
-                        checked={showHidden}
-                        onChange={() => setShowHidden(!showHidden)}
-                    />
+                    <ToggleControl label={toggleLabel} checked={showHidden} onChange={handleToggle} />
                 </PanelRow>
             )}
 

--- a/src/OptionsPanel/styles.scss
+++ b/src/OptionsPanel/styles.scss
@@ -24,7 +24,6 @@
 }
 
 .givewp-options-list {
-
     &--item {
         display: grid;
         gap: 0.5rem;
@@ -59,12 +58,14 @@
 
             &--open {
                 grid-row: span 2;
+            }
 
-                textarea {
-                    height: 64px;
-                    border: solid 1px #8c8c8c;
-                    border-radius: 2px;
-                }
+            textarea.givewp-options-list__textarea {
+                height: 64px;
+                border: solid 1px #8c8c8c;
+                border-radius: 2px;
+                width: calc(100% + 20px + .5rem); // 20px = button .5rem = gap
+                max-width: none;
             }
         }
 

--- a/src/OptionsPanel/styles.scss
+++ b/src/OptionsPanel/styles.scss
@@ -70,3 +70,26 @@
         }
     }
 }
+
+.givewp-option-description {
+    display: flex;
+    align-self: stretch;
+    height: 64px;
+    width: 100%;
+    margin-left: var(--givewp-spacing-12);
+    margin-top: var(--givewp-spacing-1);
+
+    &__input {
+        padding: var(--givewp-spacing-2);
+        border: solid 1px #8c8c8c;
+        border-radius: 2px;
+    }
+}
+
+.givewp-amount-description-toggle {
+    label {
+        text-align: right;
+        margin-right: 0;
+        max-width: 100%;
+    }
+}

--- a/src/OptionsPanel/styles.scss
+++ b/src/OptionsPanel/styles.scss
@@ -77,11 +77,3 @@
         }
     }
 }
-
-.givewp-amount-description-toggle {
-    label {
-        text-align: right;
-        margin-right: 0;
-        max-width: 100%;
-    }
-}

--- a/src/OptionsPanel/styles.scss
+++ b/src/OptionsPanel/styles.scss
@@ -59,6 +59,12 @@
 
             &--open {
                 grid-row: span 2;
+
+                textarea {
+                    height: 64px;
+                    border: solid 1px #8c8c8c;
+                    border-radius: 2px;
+                }
             }
         }
 
@@ -68,21 +74,6 @@
             min-width: fit-content !important;
             height: fit-content !important;
         }
-    }
-}
-
-.givewp-option-description {
-    display: flex;
-    align-self: stretch;
-    height: 64px;
-    width: 100%;
-    margin-left: var(--givewp-spacing-12);
-    margin-top: var(--givewp-spacing-1);
-
-    &__input {
-        padding: var(--givewp-spacing-2);
-        border: solid 1px #8c8c8c;
-        border-radius: 2px;
     }
 }
 

--- a/src/OptionsPanel/types.ts
+++ b/src/OptionsPanel/types.ts
@@ -14,6 +14,8 @@ export interface OptionsPanelProps {
     disableSoloCheckedOption?: boolean;
     draggable?: boolean;
     toggleLabel?: string;
+    toggleEnabled?: boolean;
+    onHandleToggle?: (value: boolean) => void;
 }
 
 export interface OptionsListProps {

--- a/src/OptionsPanel/types.ts
+++ b/src/OptionsPanel/types.ts
@@ -42,7 +42,6 @@ export interface OptionsItemProps {
     handleUpdateOptionValue: (value: string) => void;
     handleUpdateOptionChecked: (checked: boolean) => void;
     handleRemoveOption: () => void;
-    handleUpdateOptionDescription?: (description: string) => void;
     readOnly?: boolean;
     disabled?: boolean;
     draggable?: boolean;

--- a/src/OptionsPanel/types.ts
+++ b/src/OptionsPanel/types.ts
@@ -13,13 +13,13 @@ export interface OptionsPanelProps {
     readOnly?: boolean;
     disableSoloCheckedOption?: boolean;
     draggable?: boolean;
-    hasDescriptions?: boolean;
+    toggleLabel?: string;
 }
 
 export interface OptionsListProps {
     currency?: CurrencyCode | string;
     options: OptionProps[];
-    showValues: boolean;
+    showHidden: boolean;
     multiple: boolean;
     selectable: boolean;
     defaultControlsTooltip?: string;
@@ -28,14 +28,13 @@ export interface OptionsListProps {
     readOnly?: boolean;
     disableSoloCheckedOption?: boolean;
     draggable?: boolean;
-    showDescription?: boolean;
 }
 
 export interface OptionsItemProps {
     currency?: CurrencyCode | string;
     provided: any;
     option: OptionProps;
-    showValues: boolean;
+    showHidden: boolean;
     multiple: boolean;
     selectable: boolean;
     defaultTooltip?: string;
@@ -47,7 +46,6 @@ export interface OptionsItemProps {
     readOnly?: boolean;
     disabled?: boolean;
     draggable?: boolean;
-    showDescription?: boolean;
 }
 
 export interface OptionsHeaderProps {
@@ -61,5 +59,4 @@ export interface OptionProps {
     label: string;
     value: string;
     checked: boolean;
-    description: string;
 }

--- a/src/OptionsPanel/types.ts
+++ b/src/OptionsPanel/types.ts
@@ -13,6 +13,7 @@ export interface OptionsPanelProps {
     readOnly?: boolean;
     disableSoloCheckedOption?: boolean;
     draggable?: boolean;
+    hasDescriptions?: boolean;
 }
 
 export interface OptionsListProps {
@@ -27,6 +28,7 @@ export interface OptionsListProps {
     readOnly?: boolean;
     disableSoloCheckedOption?: boolean;
     draggable?: boolean;
+    showDescription?: boolean;
 }
 
 export interface OptionsItemProps {
@@ -41,9 +43,11 @@ export interface OptionsItemProps {
     handleUpdateOptionValue: (value: string) => void;
     handleUpdateOptionChecked: (checked: boolean) => void;
     handleRemoveOption: () => void;
+    handleUpdateOptionDescription?: (description: string) => void;
     readOnly?: boolean;
     disabled?: boolean;
     draggable?: boolean;
+    showDescription?: boolean;
 }
 
 export interface OptionsHeaderProps {
@@ -57,4 +61,5 @@ export interface OptionProps {
     label: string;
     value: string;
     checked: boolean;
+    description: string;
 }


### PR DESCRIPTION
Resolves: [GIVE-620]

## Description
This pull request enhances the OptionsPanel component by integrating a text area control dedicated to option descriptions. The primary objective is to facilitate the DonationAmount block in managing and presenting descriptions tailored to various Donation levels.

Changes:

Added a text area control within the OptionsPanel component to accommodate option descriptions.
This feature empowers the DonationAmount block to generate and manage descriptive content specific to each Donation level.

## Visuals

https://github.com/impress-org/form-builder-library/assets/75056371/d7a9e656-3076-418a-aed2-121358728188


## Testing Instructions
- In the VFB toggle the descriptions toggle to enable/disable the new fields.
- Try updating the fields and verify that they correctly save as attributes of the block.
## Pre-review Checklist

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-620]: https://stellarwp.atlassian.net/browse/GIVE-620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ