### PR TITLE
Feature: Notification Placeholder component

### DIFF
--- a/src/NotificationPlaceholder/hooks/index.ts
+++ b/src/NotificationPlaceholder/hooks/index.ts
@@ -1,49 +1,21 @@
-import {useEffect, useState} from 'react';
+import {useState} from 'react';
 
 declare const window: {
     givewpNotifications: {
         apiNonce: string;
+        notifications: {
+            user: string[];
+            system: string[];
+        };
     };
 } & Window;
 
-interface NotificationState {
-    isLoading: boolean;
-    notifications: string[];
-}
-
-export type StorageType = 'user' | 'system';
-
-/**
- * Fetch notifications
- */
-const fetchNotifications = async (type: StorageType) => {
-    //local storage
-    const notifications = JSON.parse(localStorage.getItem(`give_notifications_${type}`)) || [];
-
-    if (notifications.length > 0) {
-        return notifications;
-    }
-
-    // Server
-    const response = await fetch(`/wp-json/give-api/v2/get-notifications?type=${type}`, {
-        method: 'GET',
-        headers: {
-            'Content-Type': 'application/json',
-            'X-WP-Nonce': window.givewpNotifications.apiNonce,
-        },
-    });
-
-    const data = response.ok ? await response.json() : [];
-
-    localStorage.setItem(`give_notifications_${type}`, JSON.stringify(data));
-
-    return data;
-};
+export type NotificationType = 'user' | 'system';
 
 /**
  * Dismiss a notification
  */
-const dismissNotification = async (id: string, type: StorageType) => {
+const dismissNotification = async (id: string, type: NotificationType) => {
     const response = await fetch('/wp-json/give-api/v2/dismiss-notification', {
         method: 'POST',
         headers: {
@@ -56,39 +28,22 @@ const dismissNotification = async (id: string, type: StorageType) => {
         }),
     });
 
-    const data = response.ok ? await response.json() : [];
-
-    localStorage.setItem(`give_notifications_${type}`, JSON.stringify(data));
-
-    return data;
+    return response.ok ? await response.json() : [];
 };
 
 /**
  * Hook
  */
-export const useNotifications = (type: StorageType): [NotificationState, Function] => {
-    const [state, setState] = useState<NotificationState>({
-        isLoading: true,
-        notifications: [],
-    });
-
-    useEffect(() => {
-        fetchNotifications(type).then((notifications) => {
-            setState({
-                isLoading: false,
-                notifications,
-            });
-        });
-    }, []);
+export const useNotifications = (type: NotificationType): [Array<string>, Function] => {
+    const [notifications, setNotifications] = useState(
+        window.givewpNotifications.notifications[type]
+    );
 
     return [
-        state,
+        notifications,
         (id: string) => {
             dismissNotification(id, type).then((notifications) => {
-                setState({
-                    ...state,
-                    notifications,
-                });
+                setNotifications(notifications);
             });
         },
     ];

--- a/src/NotificationPlaceholder/hooks/index.ts
+++ b/src/NotificationPlaceholder/hooks/index.ts
@@ -1,0 +1,108 @@
+import {useEffect, useReducer} from 'react';
+
+declare const window: {
+    GiveNotifications: {
+        apiNonce: string;
+    };
+} & Window;
+
+interface NotificationState {
+    isLoading: boolean;
+    notifications: string[];
+}
+
+interface NotificationAction {
+    type: string;
+    notifications: string[];
+}
+
+/**
+ * Fetch notifications from session storage or server
+ */
+const fetchNotifications = async () => {
+    //Session storage
+    const notifications = JSON.parse(sessionStorage.getItem('give_notifications')) || [];
+
+    if (notifications.length > 0) {
+        return notifications;
+    }
+
+    // Server
+    const response = await fetch('/wp-json/give-api/v2/get-notifications', {
+        method: 'GET',
+        headers: {
+            'Content-Type': 'application/json',
+            'X-WP-Nonce': window.GiveNotifications.apiNonce
+        }
+    })
+
+    const data = response.ok ? await response.json() : [];
+
+    if (data.length > 0) {
+        sessionStorage.setItem('give_notifications', JSON.stringify(data));
+    }
+
+    return data;
+}
+
+/**
+ * Dismiss a notification
+ */
+const dismissNotification = async (id: string) => {
+    const response = await fetch('/wp-json/give-api/v2/dismiss-notification', {
+        method: 'DELETE',
+        headers: {
+            'Content-Type': 'application/json',
+            'X-WP-Nonce': window.GiveNotifications.apiNonce
+        },
+        body: JSON.stringify({notification: id})
+    })
+
+    const data = response.ok ? await response.json() : [];
+
+    sessionStorage.setItem('give_notifications', JSON.stringify(data));
+
+    return data;
+};
+
+/**
+ * Hook
+ */
+export const useNotifications = (): [NotificationState, Function] => {
+    useEffect(() => {
+        fetchNotifications().then((notifications) => {
+            dispatch({
+                type: 'SET_NOTIFICATIONS',
+                notifications
+            });
+        });
+    }, []);
+
+    const [state, dispatch] = useReducer((state: NotificationState, action: NotificationAction) => {
+        switch (action.type) {
+            case 'SET_NOTIFICATIONS':
+                return {
+                    ...state,
+                    isLoading: false,
+                    notifications: action.notifications,
+                };
+        }
+
+        return state;
+    }, {
+        isLoading: true,
+        notifications: []
+    });
+
+    return [
+        state as NotificationState,
+        (id: string) => {
+            dismissNotification(id).then((notifications) => {
+                dispatch({
+                    type: 'SET_NOTIFICATIONS',
+                    notifications
+                });
+            })
+        }
+    ];
+}

--- a/src/NotificationPlaceholder/hooks/index.ts
+++ b/src/NotificationPlaceholder/hooks/index.ts
@@ -33,9 +33,7 @@ const fetchNotifications = async () => {
 
     const data = response.ok ? await response.json() : [];
 
-    if (data.length > 0) {
-        sessionStorage.setItem('give_notifications', JSON.stringify(data));
-    }
+    sessionStorage.setItem('give_notifications', JSON.stringify(data));
 
     return data;
 }

--- a/src/NotificationPlaceholder/hooks/index.ts
+++ b/src/NotificationPlaceholder/hooks/index.ts
@@ -1,4 +1,4 @@
-import {useEffect, useReducer} from 'react';
+import {useEffect, useState} from 'react';
 
 declare const window: {
     GiveNotifications: {
@@ -8,11 +8,6 @@ declare const window: {
 
 interface NotificationState {
     isLoading: boolean;
-    notifications: string[];
-}
-
-interface NotificationAction {
-    type: string;
     notifications: string[];
 }
 
@@ -69,36 +64,26 @@ const dismissNotification = async (id: string) => {
  * Hook
  */
 export const useNotifications = (): [NotificationState, Function] => {
-    const [state, dispatch] = useReducer((state: NotificationState, action: NotificationAction) => {
-        switch (action.type) {
-            case 'SET_NOTIFICATIONS':
-                return {
-                    isLoading: false,
-                    notifications: action.notifications,
-                };
-        }
-
-        return state;
-    }, {
+    const [state, setState] = useState<NotificationState>({
         isLoading: true,
         notifications: []
     });
 
     useEffect(() => {
         fetchNotifications().then((notifications) => {
-            dispatch({
-                type: 'SET_NOTIFICATIONS',
+            setState({
+                isLoading: false,
                 notifications
             });
         });
     }, []);
 
     return [
-        state as NotificationState,
+        state,
         (id: string) => {
             dismissNotification(id).then((notifications) => {
-                dispatch({
-                    type: 'SET_NOTIFICATIONS',
+                setState({
+                    isLoading: false,
                     notifications
                 });
             })

--- a/src/NotificationPlaceholder/hooks/index.ts
+++ b/src/NotificationPlaceholder/hooks/index.ts
@@ -50,7 +50,7 @@ const fetchNotifications = async () => {
  */
 const dismissNotification = async (id: string) => {
     const response = await fetch('/wp-json/give-api/v2/dismiss-notification', {
-        method: 'DELETE',
+        method: 'POST',
         headers: {
             'Content-Type': 'application/json',
             'X-WP-Nonce': window.GiveNotifications.apiNonce

--- a/src/NotificationPlaceholder/hooks/index.ts
+++ b/src/NotificationPlaceholder/hooks/index.ts
@@ -69,20 +69,10 @@ const dismissNotification = async (id: string) => {
  * Hook
  */
 export const useNotifications = (): [NotificationState, Function] => {
-    useEffect(() => {
-        fetchNotifications().then((notifications) => {
-            dispatch({
-                type: 'SET_NOTIFICATIONS',
-                notifications
-            });
-        });
-    }, []);
-
     const [state, dispatch] = useReducer((state: NotificationState, action: NotificationAction) => {
         switch (action.type) {
             case 'SET_NOTIFICATIONS':
                 return {
-                    ...state,
                     isLoading: false,
                     notifications: action.notifications,
                 };
@@ -93,6 +83,15 @@ export const useNotifications = (): [NotificationState, Function] => {
         isLoading: true,
         notifications: []
     });
+
+    useEffect(() => {
+        fetchNotifications().then((notifications) => {
+            dispatch({
+                type: 'SET_NOTIFICATIONS',
+                notifications
+            });
+        });
+    }, []);
 
     return [
         state as NotificationState,

--- a/src/NotificationPlaceholder/index.ts
+++ b/src/NotificationPlaceholder/index.ts
@@ -1,8 +1,9 @@
+import {MouseEventHandler} from 'react';
 import {useNotifications} from './hooks';
 
 interface NotificationProps {
     id: string;
-    render: (dismiss: Function) => JSX.Element
+    render: (dismiss: MouseEventHandler) => JSX.Element
 }
 
 export default ({id, render}: NotificationProps) => {

--- a/src/NotificationPlaceholder/index.ts
+++ b/src/NotificationPlaceholder/index.ts
@@ -1,13 +1,14 @@
 import {MouseEventHandler} from 'react';
-import {useNotifications} from './hooks';
+import {useNotifications, StorageType} from './hooks';
 
 interface NotificationProps {
     id: string;
-    render: (dismiss: MouseEventHandler) => JSX.Element
+    render: (dismiss: MouseEventHandler) => JSX.Element,
+    type: StorageType;
 }
 
-export default ({id, render}: NotificationProps) => {
-    const [{isLoading, notifications}, dismissNotification] = useNotifications();
+export default ({id, render, type = 'user'}: NotificationProps) => {
+    const [{isLoading, notifications}, dismissNotification] = useNotifications(type);
 
     if (isLoading || notifications.includes(id)) {
         return null;

--- a/src/NotificationPlaceholder/index.ts
+++ b/src/NotificationPlaceholder/index.ts
@@ -1,0 +1,18 @@
+import {useNotifications} from './hooks';
+
+interface NotificationProps {
+    id: string;
+    render: (dismiss: Function) => JSX.Element
+}
+
+export default ({id, render}: NotificationProps) => {
+    const [{isLoading, notifications}, dismissNotification] = useNotifications();
+
+    if (isLoading || notifications.includes(id)) {
+        return null;
+    }
+
+    return render(() => {
+        dismissNotification(id)
+    });
+}

--- a/src/NotificationPlaceholder/index.ts
+++ b/src/NotificationPlaceholder/index.ts
@@ -1,16 +1,16 @@
 import {MouseEventHandler} from 'react';
-import {useNotifications, StorageType} from './hooks';
+import {useNotifications, NotificationType} from './hooks';
 
 interface NotificationProps {
     id: string;
     render: (dismiss: MouseEventHandler) => JSX.Element,
-    type?: StorageType;
+    type?: NotificationType;
 }
 
 export default ({id, render, type = 'user'}: NotificationProps) => {
-    const [{isLoading, notifications}, dismissNotification] = useNotifications(type);
+    const [notifications, dismissNotification] = useNotifications(type);
 
-    if (isLoading || notifications.includes(id)) {
+    if (notifications.includes(id)) {
         return null;
     }
 

--- a/src/NotificationPlaceholder/index.ts
+++ b/src/NotificationPlaceholder/index.ts
@@ -4,7 +4,7 @@ import {useNotifications, StorageType} from './hooks';
 interface NotificationProps {
     id: string;
     render: (dismiss: MouseEventHandler) => JSX.Element,
-    type: StorageType;
+    type?: StorageType;
 }
 
 export default ({id, render, type = 'user'}: NotificationProps) => {

--- a/src/NotificationPlaceholder/readme.md
+++ b/src/NotificationPlaceholder/readme.md
@@ -11,10 +11,10 @@ function App() {
             </h1>
             <NotificationPlaceholder
                 id="notificationUniqueId"
-                render={dismissNotification => (
+                render={dismiss => (
                     <div>
                         <p>Notification content</p>
-                        <button onClick={dismissNotification}>Dismiss</button>
+                        <button onClick={dismiss}>Dismiss</button>
                     </div>
                 )}
             />

--- a/src/NotificationPlaceholder/readme.md
+++ b/src/NotificationPlaceholder/readme.md
@@ -1,3 +1,8 @@
+## Notification types
+There are two notification types, `user` and `system`.
+User type notifications when dismissed, won't be shown again only to the user that dismissed the notification, while system notifications when dismissed, won't be shown again to any user.
+You will probably use `user` type notifications 99% of the time, but sometimes in some special cases like upgrade action that can be done only once for all users, you might want to use `system` type notifications.
+
 ## Usage
 
 ```jsx
@@ -13,7 +18,18 @@ function App() {
                 id="notificationUniqueId"
                 render={dismiss => (
                     <div>
-                        <p>Notification content</p>
+                        <p>User notification - if dismissed it won't be shown again to this user only.</p>
+                        <button onClick={dismiss}>Dismiss</button>
+                    </div>
+                )}
+            />
+
+            <NotificationPlaceholder
+                id="sysNotificationUniqueId"
+                type="system"
+                render={dismiss => (
+                    <div>
+                        <p>System notification - if dismissed it won't be shown again to any user.</p>
                         <button onClick={dismiss}>Dismiss</button>
                     </div>
                 )}

--- a/src/NotificationPlaceholder/readme.md
+++ b/src/NotificationPlaceholder/readme.md
@@ -1,0 +1,29 @@
+## Usage
+
+```jsx
+import {NotificationPlaceholder} from '@givewp/form-builder-library';
+
+function App() {
+    return (
+        <div>
+            <h1>
+                My app title
+            </h1>
+            <NotificationPlaceholder
+                id="notificationUniqueId"
+                render={dismissNotification => (
+                    <div>
+                        <p>Notification content</p>
+                        <button onClick={dismissNotification}>Dismiss</button>
+                    </div>
+                )}
+            />
+
+            <div>
+                My app content
+            </div>
+        </div>
+    );
+
+}
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export {default as ClassicEditor} from "./ClassicEditor";
 export {default as OptionsPanel} from "./OptionsPanel";
 export {default as SettingsSection} from "./SettingsSection";
 export {default as BlockNotice} from "./BlockNotice";
+export {default as NotificationPlaceholder} from "./NotificationPlaceholder";


### PR DESCRIPTION
## Description

This PR adds a new `NotificationPlaceholder` component to the form builder library. 

Backend https://github.com/impress-org/givewp/pull/7356

There are two types of notifications, `user` and `system`.
User type notifications when dismissed, won't be shown again only to the user that dismissed the notification, while system notifications when dismissed, won't be shown again to any user.


## Testing Instructions

```jsx
import {NotificationPlaceholder} from '@givewp/form-builder-library';

function App() {
    return (
        <div>
            <h1>
                My app title
            </h1>
            <NotificationPlaceholder
                id="notificationUniqueId"
                render={dismiss => (
                    <div>
                        <p>User notification - if dismissed it won't be shown again to this user only.</p>
                        <button onClick={dismiss}>Dismiss</button>
                    </div>
                )}
            />
            <NotificationPlaceholder
                id="sysNotificationUniqueId"
                type="system"
                render={dismiss => (
                    <div>
                        <p>System notification - if dismissed it won't be shown again to any user.</p>
                        <button onClick={dismiss}>Dismiss</button>
                    </div>
                )}
            />

            <div>
                My app content
            </div>
        </div>
    );

}
```

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

