### PR TITLE
refactor: remove label change from currency control

### DIFF
--- a/src/OptionsPanel/OptionsItem.tsx
+++ b/src/OptionsPanel/OptionsItem.tsx
@@ -61,7 +61,6 @@ export default function OptionsItem({
                             hideLabelFromVision
                             value={option.value}
                             onValueChange={(value) => {
-                                handleUpdateOptionLabel(value);
                                 handleUpdateOptionValue(value);
                             }}
                         />


### PR DESCRIPTION
## Description
With the addition of LevelDescriptions within the Donation Amount block, we've decided to use the labels attached to each amount. This unused label change method on the CurrencyInput was causing the new descriptions to be over-written.

## Affects
Amount Block

## Pre-review Checklist
-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

