### PR TITLE
Feature: Add optional length limit to OptionsPanel textarea with counter

### DIFF
--- a/src/OptionsPanel/OptionsItem.tsx
+++ b/src/OptionsPanel/OptionsItem.tsx
@@ -23,6 +23,7 @@ export default function OptionsItem({
     readOnly,
     disabled,
     draggable,
+    maxLabelLength,
 }: OptionsItemProps) {
     return (
         <div className={'givewp-options-list--item'} ref={provided.innerRef} {...provided.draggableProps}>
@@ -65,11 +66,19 @@ export default function OptionsItem({
                             }}
                         />
                         {showHidden && (
-                            <textarea
-                                className={'givewp-options-list__textarea'}
-                                value={option.label}
-                                onChange={(event) => handleUpdateOptionLabel(event.target.value)}
-                            />
+                            <div className={'givewp-options-list__textarea-wrapper'}>
+                                <textarea
+                                    className={'givewp-options-list__textarea'}
+                                    value={option.label}
+                                    onChange={(event) => handleUpdateOptionLabel(event.target.value)}
+                                    maxLength={maxLabelLength > 0 ? maxLabelLength : undefined}
+                                />
+                                {maxLabelLength > 0 && (
+                                    <span className={'givewp-options-list__textarea-counter'}>
+                                        {option?.label?.length ?? 0}/{maxLabelLength}
+                                    </span>
+                                )}
+                            </div>
                         )}
                     </>
                 ) : (

--- a/src/OptionsPanel/OptionsList.tsx
+++ b/src/OptionsPanel/OptionsList.tsx
@@ -15,6 +15,7 @@ export default function OptionsList({
     readOnly,
     disableSoloCheckedOption,
     draggable,
+    maxLabelLength,
 }: OptionsListProps) {
     const handleRemoveOption = (index: number) => (): void => {
         if (onRemoveOption) {
@@ -105,6 +106,7 @@ export default function OptionsList({
                                                 options.filter((option) => option.checked).length === 1
                                             }
                                             draggable={draggable}
+                                            maxLabelLength={maxLabelLength}
                                         />
                                     )}
                                 </Draggable>

--- a/src/OptionsPanel/index.tsx
+++ b/src/OptionsPanel/index.tsx
@@ -25,6 +25,7 @@ export default function Options({
     toggleLabel = __('Show values', 'give'),
     toggleEnabled = false,
     onHandleToggle,
+    maxLabelLength = 0,
 }: OptionsPanelProps) {
     const [showHidden, setShowHidden] = useState<boolean>(toggleEnabled);
 
@@ -65,6 +66,7 @@ export default function Options({
                         readOnly={readOnly}
                         disableSoloCheckedOption={disableSoloCheckedOption}
                         draggable={draggable}
+                        maxLabelLength={maxLabelLength}
                     />
                 </BaseControl>
             </PanelRow>

--- a/src/OptionsPanel/styles.scss
+++ b/src/OptionsPanel/styles.scss
@@ -28,7 +28,7 @@
         display: grid;
         gap: 0.5rem;
         grid-template-columns: auto auto 1fr auto;
-        grid-template-rows: 1.875rem;
+        grid-template-rows: 2rem;
         margin-top: 0.5rem;
 
         > * {
@@ -60,12 +60,25 @@
                 grid-row: span 2;
             }
 
-            textarea.givewp-options-list__textarea {
-                height: 64px;
-                border: solid 1px #8c8c8c;
-                border-radius: 2px;
-                width: calc(100% + 20px + .5rem); // 20px = button .5rem = gap
-                max-width: none;
+            .givewp-options-list__textarea {
+                &-wrapper {
+                    display: grid;
+                    gap: 2px;
+                    width: calc(100% + 20px + .5rem); // 20px = button .5rem = gap
+
+                    .givewp-options-list__textarea {
+                        height: 64px;
+                        border: solid 1px #8c8c8c;
+                        border-radius: 2px;
+                    }
+                }
+
+                &-counter {
+                    color: var(--givewp-grey-500);
+                    font-size: 0.625rem;
+                    line-height: 1.4;
+                    text-align: right;
+                }
             }
         }
 

--- a/src/OptionsPanel/types.ts
+++ b/src/OptionsPanel/types.ts
@@ -16,6 +16,7 @@ export interface OptionsPanelProps {
     toggleLabel?: string;
     toggleEnabled?: boolean;
     onHandleToggle?: (value: boolean) => void;
+    maxLabelLength?: number;
 }
 
 export interface OptionsListProps {
@@ -30,6 +31,7 @@ export interface OptionsListProps {
     readOnly?: boolean;
     disableSoloCheckedOption?: boolean;
     draggable?: boolean;
+    maxLabelLength?: number;
 }
 
 export interface OptionsItemProps {
@@ -47,6 +49,7 @@ export interface OptionsItemProps {
     readOnly?: boolean;
     disabled?: boolean;
     draggable?: boolean;
+    maxLabelLength?: number;
 }
 
 export interface OptionsHeaderProps {


### PR DESCRIPTION
Resolves [GIVE-700]

## Description
This pull request adds support for setting a length limit in the options textarea. It also includes a character counter. To use this feature, simply provide a value for the `maxLabelLength` prop of the `OptionsPanel` component.

## Affects
`OptionsPanel` component

## Visuals
![CleanShot 2024-04-29 at 17 16 00](https://github.com/impress-org/form-builder-library/assets/3921017/ae80d8d4-18a1-4374-a494-13261da8c5fa)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-700]: https://stellarwp.atlassian.net/browse/GIVE-700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ