### PR TITLE
Fix: currency control set localized value when value prop changes

### DIFF
--- a/src/CurrencyControl/index.tsx
+++ b/src/CurrencyControl/index.tsx
@@ -1,7 +1,7 @@
 import type {CurrencyInputProps} from 'react-currency-input-field';
 import CurrencyInput from 'react-currency-input-field';
 import {useInstanceId} from '@wordpress/compose';
-import {useState} from '@wordpress/element';
+import {useEffect, useState} from '@wordpress/element';
 import {BaseControl} from '@wordpress/components';
 import {CurrencyCode} from './CurrencyCode';
 import parseValueFromLocale from './parseValueFromLocale';
@@ -23,6 +23,12 @@ export default function CurrencyControl({
     ...rest
 }: CurrencyControlProps) {
     const [localizedValue, setLocalizedValue] = useState(value);
+
+     useEffect(() => {
+        if (value !== localizedValue){
+            setLocalizedValue(value);
+        }
+    }, [value]);
 
     // simplified implementation of useBaseControlProps()
     const uniqueId = useInstanceId(BaseControl, 'wp-components-base-control');


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

I found an issue with the CurrencyControl where the internal value does not get updated when the value prop changes.  In some situations this would cause the value to be cached internally.  This is most obvious when the value prop is being updated externally.

Codesandbox here to show issue: https://codesandbox.io/p/sandbox/fix-currency-control-x5g62g

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The currency control now updates its internal value when its prop value changes.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Here's a snippet to test:


```
function FeeInputs() {
  const [currencyValue, setCurrencyValue] = useState(100);

  return (
    <>
      <label>
        Type fee percentage here should be reflected in the CurrencyControl component below:
        <input type="text" onChange={(e) => setCurrencyValue(e.target.value)} />
      </label>

      <CurrencyControl
        label={"Fee Percentage"}
        value={currencyValue}
        onValueChange={(value) => setCurrencyValue(value)}
        decimalScale={1}
        maxLength={4}
        suffix="%"
        intlConfig={{ locale: window.navigator.language }}
        currency={"USD"}
      />
    </>
  );
}
```

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

