### PR TITLE
Fix: disable currency abbreviations

### DIFF
--- a/src/CurrencyControl/index.tsx
+++ b/src/CurrencyControl/index.tsx
@@ -13,6 +13,11 @@ interface CurrencyControlProps extends CurrencyInputProps {
     help?: string;
 }
 
+const formatter = new Intl.NumberFormat(navigator.language);
+const groupSeparator = formatter.format(1000).replace(/[0-9]/g, '');
+const decimalSeparator = formatter.format(1.1).replace(/[0-9]/g, '');
+
+
 export default function CurrencyControl({
     label,
     help,
@@ -24,8 +29,8 @@ export default function CurrencyControl({
 }: CurrencyControlProps) {
     const [localizedValue, setLocalizedValue] = useState(value);
 
-     useEffect(() => {
-        if (value !== localizedValue){
+    useEffect(() => {
+        if (value !== localizedValue) {
             setLocalizedValue(value);
         }
     }, [value]);
@@ -42,6 +47,15 @@ export default function CurrencyControl({
         <BaseControl label={label} help={help} id={uniqueId} hideLabelFromVision={hideLabelFromVision}>
             <CurrencyInput
                 id={uniqueId}
+                disableAbbreviations
+                decimalSeparator={decimalSeparator}
+                groupSeparator={
+                    /**
+                     * Replace non-breaking space to avoid conflict with the suffix separator.
+                     * @link https://github.com/cchanxzy/react-currency-input-field/issues/266
+                     */
+                    groupSeparator.replace(/\u00A0/g, ' ')
+                }
                 value={localizedValue}
                 onValueChange={updateValue}
                 className={'components-text-control__input'}

--- a/src/CurrencyControl/index.tsx
+++ b/src/CurrencyControl/index.tsx
@@ -4,7 +4,7 @@ import {useInstanceId} from '@wordpress/compose';
 import {useEffect, useState} from '@wordpress/element';
 import {BaseControl} from '@wordpress/components';
 import {CurrencyCode} from './CurrencyCode';
-import parseValueFromLocale from './parseValueFromLocale';
+import parseValueFromLocale, {getNumberFormattingParts} from './parseValueFromLocale';
 
 interface CurrencyControlProps extends CurrencyInputProps {
     currency: CurrencyCode;
@@ -12,10 +12,6 @@ interface CurrencyControlProps extends CurrencyInputProps {
     hideLabelFromVision?: boolean;
     help?: string;
 }
-
-const formatter = new Intl.NumberFormat(navigator.language);
-const groupSeparator = formatter.format(1000).replace(/[0-9]/g, '');
-const decimalSeparator = formatter.format(1.1).replace(/[0-9]/g, '');
 
 
 export default function CurrencyControl({
@@ -37,6 +33,8 @@ export default function CurrencyControl({
 
     // simplified implementation of useBaseControlProps()
     const uniqueId = useInstanceId(BaseControl, 'wp-components-base-control');
+
+    const {groupSeparator, decimalSeparator} = getNumberFormattingParts();
 
     const updateValue = (value: string) => {
         setLocalizedValue(value);

--- a/src/CurrencyControl/parseValueFromLocale.ts
+++ b/src/CurrencyControl/parseValueFromLocale.ts
@@ -3,11 +3,17 @@ export default function parseValueFromLocale(amount: string): string {
         return amount;
     }
 
+    const {groupSeparator, decimalSeparator} = getNumberFormattingParts();
+
+    return amount.replaceAll(groupSeparator, '').replace(decimalSeparator, '.');
+}
+
+export function getNumberFormattingParts(): { groupSeparator: string; decimalSeparator: string } {
     const numberFormat = new Intl.NumberFormat(window.navigator.language);
     const parts = numberFormat.formatToParts(1234.56);
 
-    let groupSeparator: string;
-    let decimalSeparator: string;
+    let groupSeparator = '';
+    let decimalSeparator = '';
 
     for (const part of parts) {
         if (part.type === 'group') {
@@ -17,5 +23,5 @@ export default function parseValueFromLocale(amount: string): string {
         }
     }
 
-    return amount.replaceAll(groupSeparator, '').replace(decimalSeparator, '.');
+    return {groupSeparator, decimalSeparator};
 }


### PR DESCRIPTION
Resolves : [GIVE-2138]

- Moved a related fix applied to the frontend amount field to our form-builder-library.

## Description
References:
-  https://stellarwp.atlassian.net/browse/GIVE-1985
- [Fix: disable currency abbreviations in custom amounts #7625](https://github.com/impress-org/givewp/pull/7625)
- https://github.com/cchanxzy/react-currency-input-field/issues/255
- https://github.com/cchanxzy/react-currency-input-field#abbreviations

Some languages in certain browsers update the CurrencyInput field with abbreviated letters for the value. This results in an issue where the input can render NaN or adds "000" for every additional 0 included in the input.

This PR addresses the issue by disabling the abbreviations & preventing errors with non-breaking spaces on the suffix separator.

We had implemented a similar fix for the frontend on the amount field. PR listed above.

## Affects
VFB admin side - Donation Levels UI & Setting control

## Visuals
https://github.com/user-attachments/assets/fa32a6b4-4eb4-4c31-a30b-32e8dfeb54be

## Testing Instructions
- Create a VFB form.
- Setting your Give currency to MXN peso from the currency settings.
- Update your browser language to reflect generic Spanish.
- Go to the build settings of your form -> update the donation level amounts and ensure that adding a number works properly. This includes adding or removing numbers, the UI of the input setting and the UI in the build preview.
- Might be good to double check the frontend is not affected.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1394]: https://stellarwp.atlassian.net/browse/GIVE-1394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[GIVE-2138]: https://stellarwp.atlassian.net/browse/GIVE-2138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ